### PR TITLE
feat: dockerize app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.env
+**/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:23-alpine AS base
+
+RUN apk add --no-cache sqlite
+
+WORKDIR /app
+
+RUN mkdir -p /app/db
+RUN sqlite3 /app/db/database.db "VACUUM;"
+
+COPY ./yarn.lock ./package.json ./
+
+RUN yarn install
+
+COPY ./prisma ./prisma/
+
+ENV DATABASE_URL=file:/app/db/database.db
+
+RUN npx prisma migrate dev --name init
+
+COPY ./ ./
+
+FROM node:23-alpine
+
+WORKDIR /app
+
+COPY --from=base ./app ./
+
+ENV DATABASE_URL=file:/app/db/database.db
+
+CMD ["yarn", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,43 @@
+# Base image
 FROM node:23-alpine AS base
 
+# Install SQLite
 RUN apk add --no-cache sqlite
 
+# Set working directory inside container
 WORKDIR /app
 
+# Create database folder and initialize SQLite
 RUN mkdir -p /app/db
 RUN sqlite3 /app/db/database.db "VACUUM;"
 
+# Copy package files to install dependencies
 COPY ./yarn.lock ./package.json ./
 
+# Install dependencies with Yarn
 RUN yarn install
 
+# Copy Prisma schema for migrations
 COPY ./prisma ./prisma/
 
+# Set DATABASE_URL for Prisma
 ENV DATABASE_URL=file:/app/db/database.db
 
+# Run Prisma migration to initialize DB
 RUN npx prisma migrate dev --name init
 
+# Copy the rest of the app files
 COPY ./ ./
 
+# Final app image
 FROM node:23-alpine
 
 WORKDIR /app
 
+# Copy app files from base image
 COPY --from=base ./app ./
 
 ENV DATABASE_URL=file:/app/db/database.db
 
+# Run the app in development mode
 CMD ["yarn", "dev"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ npx prisma migrate dev --name init
 yarn dev
 ```
 
+Atau pake docker
+
+```bash
+# jalankan
+docker compose up -d
+
+# untuk mematikan
+docker compose down
+```
+
 buka API Documentation
 [http://localhost:3000/api-docs](http://localhost:3000/api-docs)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  app:
+   build: .
+   ports:
+    - '3000:3000'
+   restart: unless-stopped
+   environment:
+     JWT_SECRET: NAKANO_ITSUKI
+   volumes:
+    - sqlite_data:/app/db
+volumes:
+  sqlite_data:


### PR DESCRIPTION
## What is added?

Docker stuff, so you can run it on docker without installing anything manually by yourself on your machine, just in Docker Container.

## What is changed?

README files has been modified to include running with docker just with this command:

```bash
docker compose up -d
```

## Screenshot

![Screenshot 2024-12-06 224046](https://github.com/user-attachments/assets/62da3b04-2cbc-47ee-8268-6cfb9a252f08)

## Note

If anything needs to change i'm happy to discuss further!